### PR TITLE
Update www/py-django and devel/p5-Test-Warnings

### DIFF
--- a/devel/p5-Test-Warnings/Makefile
+++ b/devel/p5-Test-Warnings/Makefile
@@ -2,12 +2,14 @@
 
 COMMENT =	test for warnings and the lack of them
 
-DISTNAME =	Test-Warnings-0.019
+DISTNAME =	Test-Warnings-0.026
 CATEGORIES =	devel
 MODULES =	cpan
 PKG_ARCH =	*
 
 MAINTAINER =	Andrew Fresh <afresh1@openbsd.org>
+
+TEST_DEPENDS +=	devel/p5-CPAN-Meta-Check
 
 # perl_5
 PERMIT_PACKAGE_CDROM =	Yes

--- a/devel/p5-Test-Warnings/distinfo
+++ b/devel/p5-Test-Warnings/distinfo
@@ -1,2 +1,2 @@
-SHA256 (Test-Warnings-0.019.tar.gz) = YYrTrh2ZXMc8KnB2y8l3oKMr8hntS9VD6y/S8PWVtGU=
-SIZE (Test-Warnings-0.019.tar.gz) = 33179
+SHA256 (Test-Warnings-0.026.tar.gz) = ritosbVhZwRZjOB/URjv5C3EYFg0RTt7K+FOJvnMmgg=
+SIZE (Test-Warnings-0.026.tar.gz) = 38058

--- a/www/py-django/lts/Makefile
+++ b/www/py-django/lts/Makefile
@@ -4,7 +4,7 @@ PORTROACH =	limit:^1\.11
 
 COMMENT =	high-level Python web framework (LTS version)
 
-MODPY_EGG_VERSION =	1.11.15
+MODPY_EGG_VERSION =	1.11.16
 LNAME =			django-lts
 REVISION =		0
 

--- a/www/py-django/lts/distinfo
+++ b/www/py-django/lts/distinfo
@@ -1,2 +1,2 @@
-SHA256 (Django-1.11.15.tar.gz) = sYI12CQm8Jcz0t6ZEM7pdc9S/wXl+DZoHrlX0QWgWkA=
-SIZE (Django-1.11.15.tar.gz) = 7843843
+SHA256 (Django-1.11.16.tar.gz) = KSaMxHgWpE8nMI5g9x2mNfVJxH2KHQA7KN5VFB33V5E=
+SIZE (Django-1.11.16.tar.gz) = 7852514

--- a/www/py-django/stable/Makefile
+++ b/www/py-django/stable/Makefile
@@ -2,7 +2,7 @@
 
 COMMENT =	high-level Python web framework
 
-MODPY_EGG_VERSION =	2.1
+MODPY_EGG_VERSION =	2.1.2
 REVISION =		0
 
 LNAME =			django

--- a/www/py-django/stable/distinfo
+++ b/www/py-django/stable/distinfo
@@ -1,2 +1,2 @@
-SHA256 (Django-2.1.tar.gz) = fyRgeNWlRvY8KPwDznH016I2d85CEJIZwkyf+yhBYTc=
-SIZE (Django-2.1.tar.gz) = 8583964
+SHA256 (Django-2.1.2.tar.gz) = 77ytfrtH2q+86tEJs4pb1Rmjw82Sxu0PaR/5f83Ra0U=
+SIZE (Django-2.1.2.tar.gz) = 8611286


### PR DESCRIPTION
1 devel/p5-Test-Warnings: update to 0.026 and add TEST_DEPENDS
2 www/py-django/stable: update to 2.1.2(include security fix)
3 www/py-django/lts: update to 1.11.16