### PR TITLE
p5-Sereal-* - Update description with warning about upgrading decoder first

### DIFF
--- a/converters/p5-Sereal-Decoder/pkg/DESCR
+++ b/converters/p5-Sereal-Decoder/pkg/DESCR
@@ -2,3 +2,8 @@ This library implements a deserializer for an efficient, compact-output,
 and feature-rich binary protocol called Sereal.
 
 Its sister module p5-Sereal-Encoder implements an encoder for this format.
+ALWAYS upgrade THIS package BEFORE upgrading the p5-Sereal-Encoder package.
+The latest version of the decoder (this package) should be able to handle
+the output from any earlier or equivalent version of the encoder. Ignoring
+this advice may result in data loss in an environment where you cannot
+upgrade the encoder simultaneously on all machines using the package.

--- a/converters/p5-Sereal-Encoder/pkg/DESCR
+++ b/converters/p5-Sereal-Encoder/pkg/DESCR
@@ -2,3 +2,8 @@ This library implements an efficient, compact-output, and feature-rich
 serializer using a binary protocol called Sereal.
 
 Its sister module p5-Sereal-Decoder implements a decoder for this format.
+ALWAYS upgrade p5-Sereal-Decoder BEFORE upgrading this package. The latest
+version of the decoder can read the output from all previous or equivalent
+versions of the encoder. However a newer encoder may produce output that an
+older decoder cannot handle. Updagrading this package without upgrading
+p5-Sereal-Decoder first may result in data loss.


### PR DESCRIPTION
The Sereal tooling is provided in two packages, one for decoding and one for encoding so that the decoder may be safely upgraded before and independently of the encoder. This allows the package to be safely upgraded in multi-host contexts where it is impossible to upgrade all machines simultaneously. Upgrading the encoder before upgrading the decoder may result in data loss in such an environment, so add a note saying as much.